### PR TITLE
Render icons in the top left corner

### DIFF
--- a/icon_font_to_png.py
+++ b/icon_font_to_png.py
@@ -125,8 +125,7 @@ def export_icon(icons, icon, size, filename, ttf_file, color, scale):
         if iteration % 2 == 0:
             factor *= 0.99
 
-    draw.text((float(size - width) / 2, float(size - height) / 2), icons[icon],
-        font=font, fill=color)
+    draw.text((0,0), icons[icon], font=font, fill=color)
 
     # Get bounding box
     bbox = image.getbbox()
@@ -136,15 +135,14 @@ def export_icon(icons, icon, size, filename, ttf_file, color, scale):
     drawmask = ImageDraw.Draw(imagemask)
 
     # Draw the icon on the mask
-    drawmask.text((float(size - width) / 2, float(size - height) / 2),
-        icons[icon], font=font, fill=255)
+    drawmask.text((0,0), icons[icon], font=font, fill=255)
 
     # Create a solid color image and apply the mask
     iconimage = Image.new("RGBA", (size,size), color)
     iconimage.putalpha(imagemask)
 
-    if bbox:
-        iconimage = iconimage.crop(bbox)
+    # Crop the icon so we can center it later
+    iconimage = iconimage.crop(bbox)
 
     borderw = int((size - (bbox[2] - bbox[0])) / 2)
     borderh = int((size - (bbox[3] - bbox[1])) / 2)


### PR DESCRIPTION
I used this script (and font-awesome-to-png in the past) to render the icons for use in [Balsamiq](http://balsamiq.com/), see [my repo](https://github.com/djfpaagman/font-awesome-balsamiq).

There was [a problem where some icons were cut off](https://github.com/djfpaagman/font-awesome-balsamiq/pull/3/files) on the sides, so I rerendered them with this script and almost succeeded, although there were still some icons being cut off, see the image below on the left (this is the `arrow-right` icon), the bottom has a slice cut off.

![betterscalingdiff](https://cloud.githubusercontent.com/assets/170034/3589925/d11f6d9e-0c52-11e4-90f3-cb4d4f011368.png)

After fiddling around with the script I managed to generate all icons like they should, as shown on the right. 

The command I used to generate generate both icons is: `python icon_font_to_png.py --size 128 --scale auto fontawesome-webfont.ttf font-awesome.css arrow-right`.

Not sure why it didn't work properly with your original code, but this seems a bit more failsafe. Unfortunately my Python knowledge is bare and I can't seem to get the tests running, so that's why I'm making this pull request. Any help is appreciated, hopefully this is also helpful to you.