### PR TITLE
Ignore CSS declaration with empty content attribute

### DIFF
--- a/icon_font_to_png/icon_font.py
+++ b/icon_font_to_png/icon_font.py
@@ -60,6 +60,8 @@ class IconFont(object):
                         # Strip quotation marks
                         if re.match("^['\"].*['\"]$", val):
                             val = val[1:-1]
+                        if val[1:] == "":
+                            continue
                         icons[name] = unichr(int(val[1:], 16))
 
         common_prefix = common_prefix or ''


### PR DESCRIPTION
I ran into an issue where the CSS parsing would break when the content attribute was empty. This change will make those declaration NOOPs and skip them.

Example erroring declaration:
```
.fa-borders:before{
  content:"";
  border: #000000 1px solid;
  padding:1px;
  border-radius:3px;
  font-size:95%;
  width:16px;
  height:16px;
  display:block
}
```